### PR TITLE
Rename namespce Cnab.Bundle to Cnab to avoid symbol name duplication

### DIFF
--- a/examples/Program.cs
+++ b/examples/Program.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Threading.Tasks;
-using Cnab.Bundle;
+using Cnab;
 using Newtonsoft.Json;
 
 namespace Examples

--- a/src/Cnab.JsonConverters/ParameterConverter.cs
+++ b/src/Cnab.JsonConverters/ParameterConverter.cs
@@ -1,6 +1,6 @@
 using System;
 
-using Cnab.Bundle;
+using Cnab;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/Cnab/Action.cs
+++ b/src/Cnab/Action.cs
@@ -1,6 +1,6 @@
 using Newtonsoft.Json;
 
-namespace Cnab.Bundle
+namespace Cnab
 {
     public class Action
     {

--- a/src/Cnab/BaseImage.cs
+++ b/src/Cnab/BaseImage.cs
@@ -1,6 +1,6 @@
 using Newtonsoft.Json;
 
-namespace Cnab.Bundle
+namespace Cnab
 {
     public class BaseImage
     {

--- a/src/Cnab/Bundle.cs
+++ b/src/Cnab/Bundle.cs
@@ -6,7 +6,7 @@ using Cnab.JsonConverters;
 using Newtonsoft.Json;
 using System.Threading.Tasks;
 
-namespace Cnab.Bundle
+namespace Cnab
 {
     public class Bundle
     {

--- a/src/Cnab/Image.cs
+++ b/src/Cnab/Image.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 using Newtonsoft.Json;
 
-namespace Cnab.Bundle
+namespace Cnab
 {
     public class Image : BaseImage
     {

--- a/src/Cnab/Location.cs
+++ b/src/Cnab/Location.cs
@@ -1,6 +1,6 @@
 using Newtonsoft.Json;
 
-namespace Cnab.Bundle
+namespace Cnab
 {
     public class Location
     {

--- a/src/Cnab/Maintainer.cs
+++ b/src/Cnab/Maintainer.cs
@@ -1,6 +1,6 @@
 using Newtonsoft.Json;
 
-namespace Cnab.Bundle
+namespace Cnab
 {
     public class Maintainer
     {

--- a/src/Cnab/Parameter.cs
+++ b/src/Cnab/Parameter.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using Cnab.JsonConverters;
 using Newtonsoft.Json;
 
-namespace Cnab.Bundle
+namespace Cnab
 {
     [JsonConverter(typeof(ParameterConverter))]
     public interface IParameterDefinition

--- a/src/Cnab/ValidationResult.cs
+++ b/src/Cnab/ValidationResult.cs
@@ -1,4 +1,4 @@
-namespace Cnab.Bundle
+namespace Cnab
 {
     public class ValidationResult
     {

--- a/test/Cnab.Bundle.Tests/BundleTests.cs
+++ b/test/Cnab.Bundle.Tests/BundleTests.cs
@@ -1,9 +1,9 @@
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Cnab.Bundle;
+using Cnab;
 
-namespace Cnab.Bundle.Tests
+namespace Cnab.Tests
 {
     [TestClass()]
     public class BundleTests

--- a/test/Cnab.Bundle.Tests/ParameterTests.cs
+++ b/test/Cnab.Bundle.Tests/ParameterTests.cs
@@ -5,7 +5,7 @@ using Cnab.Tests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 
-namespace Cnab.Bundle.Tests
+namespace Cnab.Tests
 {
     [TestClass()]
     public class ParameterTests


### PR DESCRIPTION
This PR renames the namespace `Cnab.Bundle` to `Cnab` - this simplifies clients' importing the namespace and trying to use the `Bundle` class - specifically, this avoids using `Bundle.Bundle` every time the `Bundle` class needs to be used, even if `Cnab.Bundle` was already imported.